### PR TITLE
Added support for config_loc property

### DIFF
--- a/bundles/checkstyle/.classpath
+++ b/bundles/checkstyle/.classpath
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry exported="true" kind="lib" path="lib/checkstyle-8.8-all.jar" sourcepath="lib/checkstyle-8.8-sources.jar"/>
+	<classpathentry kind="lib" path="lib/test/junit-4.12.jar" sourcepath="lib/test/junit-4.12-sources.jar"/>
+	<classpathentry kind="lib" path="lib/test/hamcrest-all-1.3.jar" sourcepath="lib/test/hamcrest-all-1.3-sources.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry exported="true" kind="lib" path="lib/checkstyle-8.8-all.jar" sourcepath="lib/checkstyle-8.8-sources.jar"/>
-	<classpathentry kind="src" path="src/"/>
-	<classpathentry kind="output" path="target/classes"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="test"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>
+

--- a/bundles/checkstyle/.classpath
+++ b/bundles/checkstyle/.classpath
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry exported="true" kind="lib" path="lib/checkstyle-8.8-all.jar" sourcepath="lib/checkstyle-8.8-sources.jar"/>
-	<classpathentry kind="lib" path="lib/test/junit-4.12.jar" sourcepath="lib/test/junit-4.12-sources.jar"/>
-	<classpathentry kind="lib" path="lib/test/hamcrest-all-1.3.jar" sourcepath="lib/test/hamcrest-all-1.3-sources.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="test"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry exported="true" kind="lib" path="lib/checkstyle-8.8-all.jar" sourcepath="lib/checkstyle-8.8-sources.jar"/>
+	<classpathentry kind="src" path="src/"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/checkstyle/.project
+++ b/bundles/checkstyle/.project
@@ -20,8 +20,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>

--- a/bundles/checkstyle/src/qa/eclipse/plugin/bundles/checkstyle/tool/CheckstyleTool.java
+++ b/bundles/checkstyle/src/qa/eclipse/plugin/bundles/checkstyle/tool/CheckstyleTool.java
@@ -88,7 +88,12 @@ public class CheckstyleTool {
 		File configFile = FileUtil.makeAbsoluteFile(configFilePath, eclipseProjectPath);
 		String absoluteConfigFilePath = configFile.toString();
 
-		PropertyResolver propertyResolver = new PropertiesExpander(new Properties());
+		/** Auto-set the config loc directory. */
+		Properties properties = new Properties();
+		properties.put("config_loc", configFile.getAbsoluteFile().getParent());
+				
+		PropertyResolver propertyResolver = new PropertiesExpander(properties);
+				
 		IgnoredModulesOptions ignoredModulesOptions = IgnoredModulesOptions.OMIT;
 		ThreadModeSettings threadModeSettings = ThreadModeSettings.SINGLE_THREAD_MODE_INSTANCE;
 		Configuration configuration;

--- a/bundles/common/.classpath
+++ b/bundles/common/.classpath
@@ -3,5 +3,5 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/common/.project
+++ b/bundles/common/.project
@@ -20,8 +20,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>


### PR DESCRIPTION
This should circumvent issues with related files in the checkstyle configuration. Unfortunately, it does not apply to DTDs used by these related files. Maybe we must add another configuration value, but I do not know the name.

Key thing is the change in  bundles/checkstyle/src/qa/eclipse/plugin/bundles/checkstyle/tool/CheckstyleTool.java all other changes where created by eclipse automatically after importing the project as maven project.